### PR TITLE
Rename Elrond to MultiversX.

### DIFF
--- a/devnet/devnet-construction-with-metadata.json
+++ b/devnet/devnet-construction-with-metadata.json
@@ -1,6 +1,6 @@
 {
     "network": {
-        "blockchain": "Elrond",
+        "blockchain": "MultiversX",
         "network": "devnet"
     },
     "data_directory": "",
@@ -23,7 +23,7 @@
                 "privkey": "3e4e89e501eb542c12403fb15c52479e8721f2f4dedc3b3ef0f3b47b37de006c",
                 "curve_type": "edwards25519",
                 "currency": {
-                    "symbol": "XEGLD",
+                    "symbol": "EGLD",
                     "decimals": 18
                 }
             }

--- a/devnet/devnet-construction-with-metadata.ros
+++ b/devnet/devnet-construction-with-metadata.ros
@@ -1,13 +1,13 @@
 transfer(1){
   transfer{
-    transfer.network = {"network":"devnet", "blockchain":"Elrond"};
-    elrond_currency = {"symbol":"XEGLD", "decimals":18};
+    transfer.network = {"network":"devnet", "blockchain":"MultiversX"};
+    native_currency = {"symbol":"EGLD", "decimals":18};
     sender = {
       "account_identifier": {
         "address": "erd1ldjsdetjvegjdnda0qw2h62kq6rpvrklkc5pw9zxm0nwulfhtyqqtyc4vq"
       },
       "currency": {
-          "symbol": "XEGLD",
+          "symbol": "EGLD",
           "decimals": 18
       }
     };
@@ -26,7 +26,7 @@ transfer(1){
         "account":{{sender.account_identifier}},
         "amount":{
           "value":{{sender_amount}},
-          "currency":{{elrond_currency}}
+          "currency":{{native_currency}}
         }
       }
     ];

--- a/devnet/devnet-construction.json
+++ b/devnet/devnet-construction.json
@@ -1,6 +1,6 @@
 {
     "network": {
-        "blockchain": "Elrond",
+        "blockchain": "MultiversX",
         "network": "devnet"
     },
     "data_directory": "",
@@ -23,7 +23,7 @@
                 "privkey": "3e4e89e501eb542c12403fb15c52479e8721f2f4dedc3b3ef0f3b47b37de006c",
                 "curve_type": "edwards25519",
                 "currency": {
-                    "symbol": "XEGLD",
+                    "symbol": "EGLD",
                     "decimals": 18
                 }
             }

--- a/devnet/devnet-construction.ros
+++ b/devnet/devnet-construction.ros
@@ -1,13 +1,13 @@
 transfer(1){
   transfer{
-    transfer.network = {"network":"devnet", "blockchain":"Elrond"};
-    elrond_currency = {"symbol":"XEGLD", "decimals":18};
+    transfer.network = {"network":"devnet", "blockchain":"MultiversX"};
+    native_currency = {"symbol":"EGLD", "decimals":18};
     sender = {
       "account_identifier": {
         "address": "erd1ldjsdetjvegjdnda0qw2h62kq6rpvrklkc5pw9zxm0nwulfhtyqqtyc4vq"
       },
       "currency": {
-          "symbol": "XEGLD",
+          "symbol": "EGLD",
           "decimals": 18
       }
     };
@@ -24,7 +24,7 @@ transfer(1){
         "address": "erd1xtslmt67utuewwv8jsx729mxjxaa8dvyyzp7492hy99dl7hvcuqq30l98v"
       },
       "currency": {
-          "symbol": "XEGLD",
+          "symbol": "EGLD",
           "decimals": 18
       }
     };
@@ -36,7 +36,7 @@ transfer(1){
         "account":{{sender.account_identifier}},
         "amount":{
           "value":{{sender_amount}},
-          "currency":{{elrond_currency}}
+          "currency":{{native_currency}}
         }
       },
       {
@@ -46,7 +46,7 @@ transfer(1){
         "account":{{recipient.account_identifier}},
         "amount":{
           "value":{{recipient_amount}},
-          "currency":{{elrond_currency}}
+          "currency":{{native_currency}}
         }
       }
     ];

--- a/devnet/devnet-data-historical.json
+++ b/devnet/devnet-data-historical.json
@@ -1,6 +1,6 @@
 {
   "network": {
-    "blockchain": "Elrond",
+    "blockchain": "MultiversX",
     "network": "devnet"
   },
   "http_timeout": 30,

--- a/devnet/http/account.http
+++ b/devnet/http/account.http
@@ -8,7 +8,7 @@ Content-Type: application/json
 
 {
   "network_identifier": {
-    "blockchain": "Elrond",
+    "blockchain": "MultiversX",
     "network": "{{baseNetwork}}"
   },
   "account_identifier": {

--- a/devnet/http/block.http
+++ b/devnet/http/block.http
@@ -8,7 +8,7 @@ Content-Type: application/json
 
 {
   "network_identifier": {
-    "blockchain": "Elrond",
+    "blockchain": "MultiversX",
     "network": "{{baseNetwork}}"
   },
   "block_identifier": {

--- a/devnet/http/construction-metadata-only.http
+++ b/devnet/http/construction-metadata-only.http
@@ -13,7 +13,7 @@ Content-Type: application/json
 
 {
     "network_identifier": {
-        "blockchain": "Elrond",
+        "blockchain": "MultiversX",
         "network": "{{baseNetwork}}"
     },
     "operations": [
@@ -26,7 +26,7 @@ Content-Type: application/json
         "sender": "erd1ldjsdetjvegjdnda0qw2h62kq6rpvrklkc5pw9zxm0nwulfhtyqqtyc4vq",
         "receiver": "erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th",
         "amount": "1",
-        "currencySymbol": "XEGLD"
+        "currencySymbol": "EGLD"
     }
 }
 
@@ -39,14 +39,14 @@ Content-Type: application/json
 
 {
     "network_identifier": {
-        "blockchain": "Elrond",
+        "blockchain": "MultiversX",
         "network": "{{baseNetwork}}"
     },
     "options": {
         "sender": "erd1ldjsdetjvegjdnda0qw2h62kq6rpvrklkc5pw9zxm0nwulfhtyqqtyc4vq",
         "receiver": "erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th",
         "amount": "1",
-        "currencySymbol": "XEGLD",
+        "currencySymbol": "EGLD",
         "gasLimit": 0,
         "gasPrice": 0,
         "data": null
@@ -62,7 +62,7 @@ Content-Type: application/json
 
 {
     "network_identifier": {
-        "blockchain": "Elrond",
+        "blockchain": "MultiversX",
         "network": "{{baseNetwork}}"
     },
     "operations": [
@@ -74,7 +74,7 @@ Content-Type: application/json
     "metadata": {
         "amount": "1",
         "chainID": "D",
-        "currencySymbol": "XEGLD",
+        "currencySymbol": "EGLD",
         "data": null,
         "gasLimit": 50000,
         "gasPrice": 1000000000,
@@ -87,7 +87,7 @@ Content-Type: application/json
         {
             "value": "50000000000000",
             "currency": {
-                "symbol": "XEGLD",
+                "symbol": "EGLD",
                 "decimals": 18
             }
         }

--- a/devnet/http/construction-one-operation-plus-metadata.http
+++ b/devnet/http/construction-one-operation-plus-metadata.http
@@ -12,7 +12,7 @@ Content-Type: application/json
 
 {
     "network_identifier": {
-        "blockchain": "Elrond",
+        "blockchain": "MultiversX",
         "network": "{{baseNetwork}}"
     },
     "operations": [
@@ -25,7 +25,7 @@ Content-Type: application/json
             "amount": {
                 "value": "1",
                 "currency": {
-                    "symbol": "XEGLD",
+                    "symbol": "EGLD",
                     "decimals": 18
                 }
             }
@@ -45,14 +45,14 @@ Content-Type: application/json
 
 {
     "network_identifier": {
-        "blockchain": "Elrond",
+        "blockchain": "MultiversX",
         "network": "{{baseNetwork}}"
     },
     "options": {
         "sender": "erd1ldjsdetjvegjdnda0qw2h62kq6rpvrklkc5pw9zxm0nwulfhtyqqtyc4vq",
         "receiver": "erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th",
         "amount": "1",
-        "currencySymbol": "XEGLD",
+        "currencySymbol": "EGLD",
         "gasLimit": 0,
         "gasPrice": 0,
         "data": null
@@ -66,7 +66,7 @@ Content-Type: application/json
 
 {
     "network_identifier": {
-        "blockchain": "Elrond",
+        "blockchain": "MultiversX",
         "network": "{{baseNetwork}}"
     },
     "operations": [
@@ -79,7 +79,7 @@ Content-Type: application/json
             "amount": {
                 "value": "1",
                 "currency": {
-                    "symbol": "XEGLD",
+                    "symbol": "EGLD",
                     "decimals": 18
                 }
             }
@@ -88,7 +88,7 @@ Content-Type: application/json
     "metadata": {
         "amount": "1",
         "chainID": "D",
-        "currencySymbol": "XEGLD",
+        "currencySymbol": "EGLD",
         "data": null,
         "gasLimit": 50000,
         "gasPrice": 1000000000,
@@ -101,7 +101,7 @@ Content-Type: application/json
         {
             "value": "50000000000000",
             "currency": {
-                "symbol": "XEGLD",
+                "symbol": "EGLD",
                 "decimals": 18
             }
         }

--- a/devnet/http/network.http
+++ b/devnet/http/network.http
@@ -16,7 +16,7 @@ Content-Type: application/json
 
 {
     "network_identifier": {
-      "blockchain": "Elrond",
+      "blockchain": "MultiversX",
       "network": "{{baseNetwork}}"
     },
     "metadata": {}
@@ -30,7 +30,7 @@ Content-Type: application/json
 
 {
   "network_identifier": {
-    "blockchain": "Elrond",
+    "blockchain": "MultiversX",
     "network": "{{baseNetwork}}"
   },
   "metadata": {}

--- a/mainnet/http/account.http
+++ b/mainnet/http/account.http
@@ -8,7 +8,7 @@ Content-Type: application/json
 
 {
   "network_identifier": {
-    "blockchain": "Elrond",
+    "blockchain": "MultiversX",
     "network": "{{baseNetwork}}"
   },
   "account_identifier": {

--- a/mainnet/http/block.http
+++ b/mainnet/http/block.http
@@ -8,7 +8,7 @@ Content-Type: application/json
 
 {
   "network_identifier": {
-    "blockchain": "Elrond",
+    "blockchain": "MultiversX",
     "network": "{{baseNetwork}}"
   },
   "block_identifier": {

--- a/mainnet/http/network.http
+++ b/mainnet/http/network.http
@@ -16,7 +16,7 @@ Content-Type: application/json
 
 {
     "network_identifier": {
-      "blockchain": "Elrond",
+      "blockchain": "MultiversX",
       "network": "{{baseNetwork}}"
     },
     "metadata": {}
@@ -30,7 +30,7 @@ Content-Type: application/json
 
 {
   "network_identifier": {
-    "blockchain": "Elrond",
+    "blockchain": "MultiversX",
     "network": "{{baseNetwork}}"
   },
   "metadata": {}

--- a/mainnet/mainnet-data-historical.json
+++ b/mainnet/mainnet-data-historical.json
@@ -1,6 +1,6 @@
 {
   "network": {
-    "blockchain": "Elrond",
+    "blockchain": "MultiversX",
     "network": "mainnet"
   },
   "http_timeout": 30,


### PR DESCRIPTION
 - `Elrond` is now `MultiversX`
 - Adjusted `network.blockchain`
 - Unrelated change: for convenience, use `EGLD` ticker name for Rosetta devnet, as well (instead of `XeGLD`) - this config change has nothing to do with renaming `Elrond` to `MultiversX`.